### PR TITLE
[Timing] Add support for warn_timeout and timeout arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.2.0] - 2019-09-20
+
+### Added
+
+- Checks can be set to a `warn` status when non-critical errors occur.
+- Timeouts can be set to add a `warn` or `fail` status to a check's messages when execution runs
+  past a set threshold.
+
+### Changed
+
+- `Handler#check` signature now takes optional params for `timeout` and `warn_timeout`.
+- The handler will report an `HTTP 203` status when a run is successful but there are warnings.
+
+## [1.1.0] - 2019-09-13
+
+### Changed
+
+- Forked from [tribune/is_it_working](https://github.com/tribune/is_it_working).

--- a/lib/is_it_working.rb
+++ b/lib/is_it_working.rb
@@ -6,7 +6,8 @@ module IsItWorking
   autoload :Filter, File.expand_path("../is_it_working/filter.rb", __FILE__)
   autoload :Handler, File.expand_path("../is_it_working/handler.rb", __FILE__)
   autoload :Status, File.expand_path("../is_it_working/status.rb", __FILE__)
-  
+  autoload :Timer, File.expand_path("../is_it_working/timer.rb", __FILE__)
+
   # Predefined checks
   autoload :ActionMailerCheck, File.expand_path("../is_it_working/checks/action_mailer_check.rb", __FILE__)
   autoload :ActiveRecordCheck, File.expand_path("../is_it_working/checks/active_record_check.rb", __FILE__)

--- a/lib/is_it_working/filter.rb
+++ b/lib/is_it_working/filter.rb
@@ -4,28 +4,30 @@ module IsItWorking
     class AsyncRunner < Thread
       attr_accessor :filter_status
     end
-    
+
     class SyncRunner
       attr_accessor :filter_status
-      
+
       def initialize
         yield
       end
-      
+
       def join
       end
     end
-    
-    attr_reader :name, :async
-    
+
+    attr_reader :name, :async, :warn_timeout, :timeout
+
     # Create a new filter to run a status check. The name is used for display purposes.
-    def initialize(name, check, async = true)
+    def initialize(name, check, async = true, options = {})
       @name = name
       @check = check
       @async = async
+      @warn_timeout = options[:warn_timeout] || Float::INFINITY
+      @timeout = options[:timeout] || Float::INFINITY
     end
-    
-    # Run a status the status check. This method keeps track of the time it took to run
+
+    # Run a status check. This method keeps track of the time it took to run
     # the check and will trap any unexpected exceptions and report them as failures.
     def run
       status = Status.new(name)
@@ -37,19 +39,43 @@ module IsItWorking
           status.fail("#{name} error: #{e.inspect}")
         end
         status.time = Time.now - t
+        handle_timing! status
       end
       runner.filter_status = status
       runner
     end
-    
+
     class << self
       # Run a list of filters and return their status objects
-      def run_filters (filters)
+      def run_filters(filters)
         runners = filters.collect{|f| f.run}
         statuses = runners.collect{|runner| runner.filter_status}
         runners.each{|runner| runner.join}
         statuses
       end
+    end
+
+    private
+
+    def handle_timing!(status)
+      if fail_timeout_exceeded?(status.time)
+        status.fail("runtime exceeded critical threshold: #{timeout}ms")
+      elsif warn_timeout_exceeded?(status.time)
+        status.warn("runtime exceeded warning threshold: #{warn_timeout}ms")
+      end
+    end
+
+    def warn_timeout_exceeded?(time)
+      timeout_exceeded? time, warn_timeout
+    end
+
+    def fail_timeout_exceeded?(time)
+      timeout_exceeded? time, timeout
+    end
+
+    def timeout_exceeded?(time, val)
+      # binding.pry if time == nil
+      time * 1000 > val
     end
   end
 end

--- a/lib/is_it_working/filter.rb
+++ b/lib/is_it_working/filter.rb
@@ -16,22 +16,20 @@ module IsItWorking
       end
     end
 
-    attr_reader :name, :async, :warn_timeout, :timeout
+    attr_reader :async, :name, :runner, :status
 
     # Create a new filter to run a status check. The name is used for display purposes.
-    def initialize(name, check, async = true, options = {})
+    def initialize(name, check, async = true)
       @name = name
       @check = check
       @async = async
-      @warn_timeout = options[:warn_timeout] || Float::INFINITY
-      @timeout = options[:timeout] || Float::INFINITY
+      @status = Status.new(name)
     end
 
     # Run a status check. This method keeps track of the time it took to run
     # the check and will trap any unexpected exceptions and report them as failures.
     def run
-      status = Status.new(name)
-      runner = (async ? AsyncRunner : SyncRunner).new do
+      @runner = (async ? AsyncRunner : SyncRunner).new do
         t = Time.now
         begin
           @check.call(status)
@@ -39,7 +37,6 @@ module IsItWorking
           status.fail("#{name} error: #{e.inspect}")
         end
         status.time = Time.now - t
-        handle_timing! status
       end
       runner.filter_status = status
       runner
@@ -48,34 +45,9 @@ module IsItWorking
     class << self
       # Run a list of filters and return their status objects
       def run_filters(filters)
-        runners = filters.collect{|f| f.run}
-        statuses = runners.collect{|runner| runner.filter_status}
-        runners.each{|runner| runner.join}
-        statuses
+        filters.map(&:run).each(&:join)
+        filters.map(&:status)
       end
-    end
-
-    private
-
-    def handle_timing!(status)
-      if fail_timeout_exceeded?(status.time)
-        status.fail("runtime exceeded critical threshold: #{timeout}ms")
-      elsif warn_timeout_exceeded?(status.time)
-        status.warn("runtime exceeded warning threshold: #{warn_timeout}ms")
-      end
-    end
-
-    def warn_timeout_exceeded?(time)
-      timeout_exceeded? time, warn_timeout
-    end
-
-    def fail_timeout_exceeded?(time)
-      timeout_exceeded? time, timeout
-    end
-
-    def timeout_exceeded?(time, val)
-      # binding.pry if time == nil
-      time * 1000 > val
     end
   end
 end

--- a/lib/is_it_working/handler.rb
+++ b/lib/is_it_working/handler.rb
@@ -95,7 +95,7 @@ module IsItWorking
         end
       end
 
-      @filters << Filter.new(name, check, options[:async])
+      @filters << Filter.new(name, check, options[:async], options)
     end
 
     # Helper method to synchronize a block of code so it can be thread safe.

--- a/lib/is_it_working/handler.rb
+++ b/lib/is_it_working/handler.rb
@@ -124,12 +124,12 @@ module IsItWorking
 
     # Output the plain text response from calling all the filters.
     def render(statuses, elapsed_time) #:nodoc:
-      code = if statuses.any?(&:warnings?)
-               203
-             elsif statuses.all?(&:success?)
-               200
-             else
+      code = if statuses.any?(&:failures?)
                500
+             elsif statuses.any?(&:warnings?)
+               203
+             else
+               200
              end
       headers = {
         "Content-Type" => "text/plain; charset=utf8",

--- a/lib/is_it_working/status.rb
+++ b/lib/is_it_working/status.rb
@@ -23,6 +23,10 @@ module IsItWorking
       def warn?
         result == :warn
       end
+
+      def fail?
+        result == :fail
+      end
     end
 
     # The name of the status check for display purposes.
@@ -62,6 +66,11 @@ module IsItWorking
     # Returns +true+ if all checks were OK but warnings were present.
     def warnings?
       success? && @messages.any?{|m| m.warn?}
+    end
+
+    # Returns +true+ if any checks were FAIL.
+    def failures?
+      @messages.any?{|m| m.fail?}
     end
   end
 end

--- a/lib/is_it_working/timer.rb
+++ b/lib/is_it_working/timer.rb
@@ -1,0 +1,41 @@
+module IsItWorking
+  class Timer
+    attr_reader :failure_threshold, :filter, :warning_threshold
+
+    def initialize(threshold = Float::INFINITY, warn: Float::INFINITY)
+      @failure_threshold = threshold
+      @warning_threshold = warn
+      @filter = yield
+    end
+
+    def call
+      status = filter.status
+      if fail_timeout_exceeded?(status.time)
+        status.fail("runtime exceeded critical threshold: #{failure_threshold}ms")
+      elsif warn_timeout_exceeded?(status.time)
+        status.warn("runtime exceeded warning threshold: #{warning_threshold}ms")
+      end
+    end
+
+    class << self
+      def run_timers(timers)
+        timers.each(&:call)
+      end
+    end
+
+    private
+
+    def warn_timeout_exceeded?(time)
+      timeout_exceeded? time, warning_threshold
+    end
+
+    def fail_timeout_exceeded?(time)
+      timeout_exceeded? time, failure_threshold
+    end
+
+    def timeout_exceeded?(time, val)
+      # binding.pry if time == nil
+      time * 1000 > val
+    end
+  end
+end

--- a/lib/is_it_working/version.rb
+++ b/lib/is_it_working/version.rb
@@ -1,3 +1,3 @@
 module IsItWorking
-  VERSION = '1.1.0'.freeze
+  VERSION = '1.2.0'.freeze
 end

--- a/spec/filter_spec.rb
+++ b/spec/filter_spec.rb
@@ -1,17 +1,17 @@
 require File.expand_path('../spec_helper', __FILE__)
 
 describe IsItWorking::Filter do
-  
+
   it "should have a name" do
     filter = IsItWorking::Filter.new(:test, lambda{})
     filter.name.should == :test
   end
-  
+
   it "should run a check and return a thread" do
     check = lambda do |status|
       status.ok("success")
     end
-    
+
     filter = IsItWorking::Filter.new(:test, check)
     runner = filter.run
     status = runner.filter_status
@@ -20,12 +20,12 @@ describe IsItWorking::Filter do
     status.messages.first.message.should == "success"
     status.time.should_not be_nil
   end
-  
-  it "should run a check and recue an errors" do
+
+  it "should run a check and rescue an error" do
     check = lambda do |status|
       raise "boom!"
     end
-    
+
     filter = IsItWorking::Filter.new(:test, check)
     runner = filter.run
     status = runner.filter_status
@@ -34,7 +34,13 @@ describe IsItWorking::Filter do
     status.messages.first.message.should include("boom")
     status.time.should_not be_nil
   end
-  
+
+  it "should have a warn state when exceeding the warn_threshold" do
+  end
+
+  it "should have a warn state when exceeding the warn_threshold" do
+  end
+
   it "should run multiple filters and return their statuses" do
     filter_1 = IsItWorking::Filter.new(:test, lambda{|status| status.ok("OK")})
     filter_2 = IsItWorking::Filter.new(:test, lambda{|status| status.fail("FAIL")})
@@ -42,5 +48,5 @@ describe IsItWorking::Filter do
     statuses.first.should be_success
     statuses.last.should_not be_success
   end
-  
+
 end

--- a/spec/handler_spec.rb
+++ b/spec/handler_spec.rb
@@ -100,26 +100,32 @@ describe IsItWorking::Handler do
 
   it "should return a warning status if a check exceeds a warning timeout" do
     handler = IsItWorking::Handler.new do |h|
-      h.check :block, warn_timeout: 900 do |status|
-        sleep 1
-        status.ok('That took a while! 😅')
+      h.timer(warn: 1) do
+        h.check :block do |status|
+          sleep 0.02
+          status.ok('That took a while! 😅')
+        end
       end
     end
     response = handler.call({})
-    response.first.should == 203
+    response.first.should == 302
     response.last.flatten.join.should include("OK: block - That took a while")
     response.last.flatten.join.should include("WARN: block - runtime exceeded warning threshold")
   end
 
     it "should return a failure status if a check exceeds a warning timeout and a timeout" do
     handler = IsItWorking::Handler.new do |h|
-      h.check :block,  warn_timeout: 5, timeout: 9 do |status|
-        sleep 0.1
-        status.ok('That took a while! 😅')
+      h.timer(9, warn: 5) do
+        h.check :block do |status|
+          sleep 0.1
+          status.ok('That took a while! 😅')
+        end
       end
-      h.check :warn, warn_timeout: 5 do |status|
-        sleep 0.1
-        status.ok('That took a while! 😅')
+      h.timer(warn: 5) do
+        h.check :warn do |status|
+          sleep 0.1
+          status.ok('That took a while! 😅')
+        end
       end
     end
     response = handler.call({})

--- a/spec/handler_spec.rb
+++ b/spec/handler_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe IsItWorking::Handler do
-  
+
   it "should lookup filters from the pre-defined checks" do
     handler = IsItWorking::Handler.new do |h|
       h.check :directory, :path => ".", :permissions => :read
@@ -11,7 +11,7 @@ describe IsItWorking::Handler do
     response.last.flatten.join("").should include("OK")
     response.last.flatten.join("").should include("directory")
   end
-  
+
   it "should use blocks as filters" do
     handler = IsItWorking::Handler.new do |h|
       h.check :block do |status|
@@ -23,7 +23,7 @@ describe IsItWorking::Handler do
     response.last.flatten.join("").should include("OK")
     response.last.flatten.join("").should include("block - Okey dokey")
   end
-  
+
   it "should use object as filters" do
     handler = IsItWorking::Handler.new do |h|
       h.check :lambda, lambda{|status| status.ok("A-okay")}
@@ -33,7 +33,7 @@ describe IsItWorking::Handler do
     response.last.flatten.join("").should include("OK")
     response.last.flatten.join("").should include("lambda - A-okay")
   end
-  
+
   it "should create asynchronous filters by default" do
     handler = IsItWorking::Handler.new do |h|
       h.check :block do |status|
@@ -44,7 +44,7 @@ describe IsItWorking::Handler do
     IsItWorking::Filter::AsyncRunner.should_receive(:new).and_return(runner)
     response = handler.call({})
   end
-  
+
   it "should be able to create synchronous filters" do
     handler = IsItWorking::Handler.new do |h|
       h.check :block, :async => false do |status|
@@ -55,7 +55,7 @@ describe IsItWorking::Handler do
     IsItWorking::Filter::SyncRunner.should_receive(:new).and_return(runner)
     response = handler.call({})
   end
-  
+
   it "should work with synchronous checks" do
     handler = IsItWorking::Handler.new do |h|
       h.check :block, :async => false do |status|
@@ -67,7 +67,7 @@ describe IsItWorking::Handler do
     response.last.flatten.join("").should include("OK")
     response.last.flatten.join("").should include("block - Okey dokey")
   end
-  
+
   it "should return a success response if all checks pass" do
     handler = IsItWorking::Handler.new do |h|
       h.check :block do |status|
@@ -82,7 +82,7 @@ describe IsItWorking::Handler do
     response.last.flatten.join("").should include("block - success")
     response.last.flatten.join("").should include("block - worked")
   end
-  
+
   it "should return an error response if any check fails" do
     handler = IsItWorking::Handler.new do |h|
       h.check :block do |status|
@@ -97,7 +97,33 @@ describe IsItWorking::Handler do
     response.last.flatten.join("").should include("block - success")
     response.last.flatten.join("").should include("block - down")
   end
-  
+
+  it "should return a warning status if a check exceeds a warning timeout" do
+    handler = IsItWorking::Handler.new do |h|
+      h.check :block, warn_timeout: 900 do |status|
+        sleep 1
+        status.ok('That took a while! 😅')
+      end
+    end
+    response = handler.call({})
+    response.first.should == 203
+    response.last.flatten.join.should include("OK: block - That took a while")
+    response.last.flatten.join.should include("WARN: block - runtime exceeded warning threshold")
+  end
+
+    it "should return a failure status if a check exceeds a warning timeout and a timeout" do
+    handler = IsItWorking::Handler.new do |h|
+      h.check :block,  warn_timeout: 500, timeout: 900 do |status|
+        sleep 1
+        status.ok('That took a while! 😅')
+      end
+    end
+    response = handler.call({})
+    response.first.should == 500
+    response.last.flatten.join.should include("OK: block - That took a while")
+    response.last.flatten.join.should include("FAIL: block - runtime exceeded critical threshold")
+  end
+
   it "should be able to be used in a middleware stack with the route /is_it_working" do
     app_response = [200, {"Content-Type" => "text/plain"}, ["OK"]]
     app = lambda{|env| app_response}
@@ -105,13 +131,13 @@ describe IsItWorking::Handler do
     stack = IsItWorking::Handler.new(app) do |h|
       h.check(:test){|status| check_called = true; status.ok("Woot!")}
     end
-    
+
     stack.call("PATH_INFO" => "/").should == app_response
     check_called.should == false
     stack.call("PATH_INFO" => "/is_it_working").last.flatten.join("").should include("Woot!")
     check_called.should == true
   end
-  
+
   it "should be able to be used in a middleware stack with a custom route" do
     app_response = [200, {"Content-Type" => "text/plain"}, ["OK"]]
     app = lambda{|env| app_response}
@@ -119,19 +145,19 @@ describe IsItWorking::Handler do
     stack = IsItWorking::Handler.new(app, "/woot") do |h|
       h.check(:test){|status| check_called = true; status.ok("Woot!")}
     end
-    
+
     stack.call("PATH_INFO" => "/is_it_working").should == app_response
     check_called.should == false
     stack.call("PATH_INFO" => "/woot").last.flatten.join("").should include("Woot!")
     check_called.should == true
   end
-  
+
   it "should be able to synchronize access to a block" do
     handler = IsItWorking::Handler.new
     handler.synchronize{1}.should == 1
     handler.synchronize{2}.should == 2
   end
-  
+
   it "should be able to set the host name reported in the output" do
     handler = IsItWorking::Handler.new
     handler.hostname = "woot"

--- a/spec/handler_spec.rb
+++ b/spec/handler_spec.rb
@@ -113,8 +113,12 @@ describe IsItWorking::Handler do
 
     it "should return a failure status if a check exceeds a warning timeout and a timeout" do
     handler = IsItWorking::Handler.new do |h|
-      h.check :block,  warn_timeout: 500, timeout: 900 do |status|
-        sleep 1
+      h.check :block,  warn_timeout: 5, timeout: 9 do |status|
+        sleep 0.1
+        status.ok('That took a while! 😅')
+      end
+      h.check :warn, warn_timeout: 5 do |status|
+        sleep 0.1
         status.ok('That took a while! 😅')
       end
     end

--- a/spec/status_spec.rb
+++ b/spec/status_spec.rb
@@ -34,6 +34,16 @@ describe IsItWorking::Status do
     status.messages.first.message.should == "uh oh"
   end
 
+  it "should have failures" do
+    status.fail("uh oh")
+    status.should be_failures
+    status.messages.size.should == 1
+    status.messages.first.should_not be_ok
+    status.messages.first.should_not be_warn
+    status.messages.first.should be_fail
+    status.messages.first.message.should == "uh oh"
+  end
+
   it "should have both errors and successes" do
     status.fail("boom")
     status.ok("wow")


### PR DESCRIPTION
Now that our fork of is_it_working can respond to `status.warn` we can expose timing awareness for all checks via params to `h.check`. An example, using a native check to is_it_working:
```
  # Check the memcache servers used by Rails.cache if using the DalliStore implementation
  h.check :dalli, timeout: 5, warn_timeout: 1, :cache => Rails.cache if defined?(ActiveSupport::Cache::DalliStore) && Rails.cache.is_a?(ActiveSupport::Cache::DalliStore)
```
This would add a `status.warn` if the ping exceeded 1ms, and a status.fail if it exceeded 5ms.

Examples from stores:
![image](https://user-images.githubusercontent.com/72645/65262311-0dc02c80-dad8-11e9-9b10-d9182700c9ad.png)
