### PR TITLE
Add `h.timer` to fail or warn statuses based on execution time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.2.0] - 2019-09-20
+## [1.2.0] - Unreleased
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.2.0] - Unreleased
+## [1.2.0] - 2019-11-15
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Checks can be set to a `warn` status when non-critical errors occur.
-- Timeouts can be set to add a `warn` or `fail` status to a check's messages when execution runs
-  past a set threshold.
+- Handler now exposes a `timer` method which can wrap a check and ok/warn/fail it based on how long it takes
 
 ### Changed
 
-- `Handler#check` signature now takes optional params for `timeout` and `warn_timeout`.
-- The handler will report an `HTTP 203` status when a run is successful but there are warnings.
+- The handler will report an `HTTP 302` status when a run is successful but there are warnings.
 
 ## [1.1.0] - 2019-09-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.2.0] - 2019-09-20
+
+### Added
+
+- Checks can be set to a `warn` status when non-critical errors occur.
+- Timeouts can be set to add a `warn` or `fail` status to a check's messages when execution runs
+  past a set threshold.
+
+### Changed
+
+- `Handler#check` signature now takes optional params for `timeout` and `warn_timeout`.
+- The handler will report an `HTTP 203` status when a run is successful but there are warnings.
+
+## [1.1.0] - 2019-09-13
+
+### Changed
+
+- Forked from [tribune/is_it_working](https://github.com/tribune/is_it_working).

--- a/README.rdoc
+++ b/README.rdoc
@@ -18,28 +18,29 @@ Suppose you have a Rails application that uses the following services:
 * NFS shared directory symlinked to from system/data in the Rails root directory
 * SMTP server at mail.example.com
 * A black box service encapsulated in AwesomeService
+* A sidekiq queue that should be monitored for retries that aren't clearing out
 
 A monitoring handler for this set up could be set up in <tt>config/initializers/is_it_working.rb</tt> like this:
 
   Rails.configuration.middleware.use(IsItWorking::Handler) do |h|
     # Check the ActiveRecord database connection without spawning a new thread
     h.check :active_record, :async => false
-    
+
     # Check the memcache servers used by Rails.cache if using the DalliStore implementation
     h.check :dalli, :cache => Rails.cache if defined?(ActiveSupport::Cache::DalliStore) && Rails.cache.is_a?(ActiveSupport::Cache::DalliStore)
-    
+
     # Check that the web service is working by hitting a known URL with Basic authentication
     h.check :url, :get => "http://api.example.com/version", :username => "appname", :password => "abc123"
-    
+
     # Check that the NFS mount directory is available with read/write permissions
     h.check :directory, :path => Rails.root + "system/data", :permission => [:read, :write]
-    
+
     # Check the mail server configured for ActionMailer
     h.check :action_mailer if ActionMailer::Base.delivery_method == :smtp
-    
+
     # Ping another mail server
     h.check :ping, :host => "mail.example.com", :port => "smtp"
-    
+
     # Check that AwesomeService is working using the service's own logic
     h.check :awesome_service do |status|
       if AwesomeService.active?

--- a/lib/is_it_working.rb
+++ b/lib/is_it_working.rb
@@ -6,7 +6,8 @@ module IsItWorking
   autoload :Filter, File.expand_path("../is_it_working/filter.rb", __FILE__)
   autoload :Handler, File.expand_path("../is_it_working/handler.rb", __FILE__)
   autoload :Status, File.expand_path("../is_it_working/status.rb", __FILE__)
-  
+  autoload :Timer, File.expand_path("../is_it_working/timer.rb", __FILE__)
+
   # Predefined checks
   autoload :ActionMailerCheck, File.expand_path("../is_it_working/checks/action_mailer_check.rb", __FILE__)
   autoload :ActiveRecordCheck, File.expand_path("../is_it_working/checks/active_record_check.rb", __FILE__)

--- a/lib/is_it_working/filter.rb
+++ b/lib/is_it_working/filter.rb
@@ -23,12 +23,12 @@ module IsItWorking
       @name = name
       @check = check
       @async = async
-      @status = Status.new(name)
     end
 
     # Run a status check. This method keeps track of the time it took to run
     # the check and will trap any unexpected exceptions and report them as failures.
     def run
+      @status = Status.new(name)
       @runner = (async ? AsyncRunner : SyncRunner).new do
         t = Time.now
         begin

--- a/lib/is_it_working/filter.rb
+++ b/lib/is_it_working/filter.rb
@@ -4,28 +4,30 @@ module IsItWorking
     class AsyncRunner < Thread
       attr_accessor :filter_status
     end
-    
+
     class SyncRunner
       attr_accessor :filter_status
-      
+
       def initialize
         yield
       end
-      
+
       def join
       end
     end
-    
-    attr_reader :name, :async
-    
+
+    attr_reader :name, :async, :warn_timeout, :timeout
+
     # Create a new filter to run a status check. The name is used for display purposes.
-    def initialize(name, check, async = true)
+    def initialize(name, check, async = true, options = {})
       @name = name
       @check = check
       @async = async
+      @warn_timeout = options[:warn_timeout] || Float::INFINITY
+      @timeout = options[:timeout] || Float::INFINITY
     end
-    
-    # Run a status the status check. This method keeps track of the time it took to run
+
+    # Run a status check. This method keeps track of the time it took to run
     # the check and will trap any unexpected exceptions and report them as failures.
     def run
       status = Status.new(name)
@@ -37,19 +39,43 @@ module IsItWorking
           status.fail("#{name} error: #{e.inspect}")
         end
         status.time = Time.now - t
+        handle_timing! status
       end
       runner.filter_status = status
       runner
     end
-    
+
     class << self
       # Run a list of filters and return their status objects
-      def run_filters (filters)
+      def run_filters(filters)
         runners = filters.collect{|f| f.run}
         statuses = runners.collect{|runner| runner.filter_status}
         runners.each{|runner| runner.join}
         statuses
       end
+    end
+
+    private
+
+    def handle_timing!(status)
+      if fail_timeout_exceeded?(status.time)
+        status.fail("runtime exceeded critical threshold: #{timeout}ms")
+      elsif warn_timeout_exceeded?(status.time)
+        status.warn("runtime exceeded warning threshold: #{warn_timeout}ms")
+      end
+    end
+
+    def warn_timeout_exceeded?(time)
+      timeout_exceeded? time, warn_timeout
+    end
+
+    def fail_timeout_exceeded?(time)
+      timeout_exceeded? time, timeout
+    end
+
+    def timeout_exceeded?(time, val)
+      # binding.pry if time == nil
+      time * 1000 > val
     end
   end
 end

--- a/lib/is_it_working/filter.rb
+++ b/lib/is_it_working/filter.rb
@@ -16,22 +16,20 @@ module IsItWorking
       end
     end
 
-    attr_reader :name, :async, :warn_timeout, :timeout
+    attr_reader :async, :name, :runner, :status
 
     # Create a new filter to run a status check. The name is used for display purposes.
-    def initialize(name, check, async = true, options = {})
+    def initialize(name, check, async = true)
       @name = name
       @check = check
       @async = async
-      @warn_timeout = options[:warn_timeout] || Float::INFINITY
-      @timeout = options[:timeout] || Float::INFINITY
+      @status = Status.new(name)
     end
 
     # Run a status check. This method keeps track of the time it took to run
     # the check and will trap any unexpected exceptions and report them as failures.
     def run
-      status = Status.new(name)
-      runner = (async ? AsyncRunner : SyncRunner).new do
+      @runner = (async ? AsyncRunner : SyncRunner).new do
         t = Time.now
         begin
           @check.call(status)
@@ -39,7 +37,6 @@ module IsItWorking
           status.fail("#{name} error: #{e.inspect}")
         end
         status.time = Time.now - t
-        handle_timing! status
       end
       runner.filter_status = status
       runner
@@ -48,34 +45,9 @@ module IsItWorking
     class << self
       # Run a list of filters and return their status objects
       def run_filters(filters)
-        runners = filters.collect{|f| f.run}
-        statuses = runners.collect{|runner| runner.filter_status}
-        runners.each{|runner| runner.join}
-        statuses
+        filters.map(&:run).each(&:join)
+        filters.map(&:status)
       end
-    end
-
-    private
-
-    def handle_timing!(status)
-      if fail_timeout_exceeded?(status.time)
-        status.fail("runtime exceeded critical threshold: #{timeout}ms")
-      elsif warn_timeout_exceeded?(status.time)
-        status.warn("runtime exceeded warning threshold: #{warn_timeout}ms")
-      end
-    end
-
-    def warn_timeout_exceeded?(time)
-      timeout_exceeded? time, warn_timeout
-    end
-
-    def fail_timeout_exceeded?(time)
-      timeout_exceeded? time, timeout
-    end
-
-    def timeout_exceeded?(time, val)
-      # binding.pry if time == nil
-      time * 1000 > val
     end
   end
 end

--- a/lib/is_it_working/handler.rb
+++ b/lib/is_it_working/handler.rb
@@ -95,7 +95,7 @@ module IsItWorking
         end
       end
 
-      @filters << Filter.new(name, check, options[:async])
+      @filters << Filter.new(name, check, options[:async], options)
     end
 
     # Helper method to synchronize a block of code so it can be thread safe.

--- a/lib/is_it_working/handler.rb
+++ b/lib/is_it_working/handler.rb
@@ -124,12 +124,12 @@ module IsItWorking
 
     # Output the plain text response from calling all the filters.
     def render(statuses, elapsed_time) #:nodoc:
-      code = if statuses.any?(&:warnings?)
-               203
-             elsif statuses.all?(&:success?)
-               200
-             else
+      code = if statuses.any?(&:failures?)
                500
+             elsif statuses.any?(&:warnings?)
+               203
+             else
+               200
              end
       headers = {
         "Content-Type" => "text/plain; charset=utf8",

--- a/lib/is_it_working/status.rb
+++ b/lib/is_it_working/status.rb
@@ -60,17 +60,17 @@ module IsItWorking
 
     # Returns +true+ only if all checks were OK.
     def success?
-      @messages.all?{|m| m.ok?}
+      @messages.all?(&:ok?)
     end
 
     # Returns +true+ if all checks were OK but warnings were present.
     def warnings?
-      success? && @messages.any?{|m| m.warn?}
+      success? && @messages.any?(&:warn?)
     end
 
     # Returns +true+ if any checks were FAIL.
     def failures?
-      @messages.any?{|m| m.fail?}
+      @messages.any?(&:fail?)
     end
   end
 end

--- a/lib/is_it_working/status.rb
+++ b/lib/is_it_working/status.rb
@@ -23,6 +23,10 @@ module IsItWorking
       def warn?
         result == :warn
       end
+
+      def fail?
+        result == :fail
+      end
     end
 
     # The name of the status check for display purposes.
@@ -62,6 +66,11 @@ module IsItWorking
     # Returns +true+ if all checks were OK but warnings were present.
     def warnings?
       success? && @messages.any?{|m| m.warn?}
+    end
+
+    # Returns +true+ if any checks were FAIL.
+    def failures?
+      @messages.any?{|m| m.fail?}
     end
   end
 end

--- a/lib/is_it_working/timer.rb
+++ b/lib/is_it_working/timer.rb
@@ -2,9 +2,9 @@ module IsItWorking
   class Timer
     attr_reader :failure_threshold, :filter, :warning_threshold
 
-    def initialize(threshold = Float::INFINITY, warn: Float::INFINITY)
-      @failure_threshold = threshold
-      @warning_threshold = warn
+    def initialize(warn_after: Float::INFINITY, fail_after: Float::INFINITY)
+      @failure_threshold = fail_after
+      @warning_threshold = warn_after
       @filter = yield
     end
 

--- a/lib/is_it_working/timer.rb
+++ b/lib/is_it_working/timer.rb
@@ -34,7 +34,6 @@ module IsItWorking
     end
 
     def timeout_exceeded?(time, val)
-      # binding.pry if time == nil
       time * 1000 > val
     end
   end

--- a/lib/is_it_working/timer.rb
+++ b/lib/is_it_working/timer.rb
@@ -1,0 +1,41 @@
+module IsItWorking
+  class Timer
+    attr_reader :failure_threshold, :filter, :warning_threshold
+
+    def initialize(threshold = Float::INFINITY, warn: Float::INFINITY)
+      @failure_threshold = threshold
+      @warning_threshold = warn
+      @filter = yield
+    end
+
+    def call
+      status = filter.status
+      if fail_timeout_exceeded?(status.time)
+        status.fail("runtime exceeded critical threshold: #{failure_threshold}ms")
+      elsif warn_timeout_exceeded?(status.time)
+        status.warn("runtime exceeded warning threshold: #{warning_threshold}ms")
+      end
+    end
+
+    class << self
+      def run_timers(timers)
+        timers.each(&:call)
+      end
+    end
+
+    private
+
+    def warn_timeout_exceeded?(time)
+      timeout_exceeded? time, warning_threshold
+    end
+
+    def fail_timeout_exceeded?(time)
+      timeout_exceeded? time, failure_threshold
+    end
+
+    def timeout_exceeded?(time, val)
+      # binding.pry if time == nil
+      time * 1000 > val
+    end
+  end
+end

--- a/lib/is_it_working/version.rb
+++ b/lib/is_it_working/version.rb
@@ -1,3 +1,3 @@
 module IsItWorking
-  VERSION = '1.1.0'.freeze
+  VERSION = '1.2.0'.freeze
 end

--- a/spec/filter_spec.rb
+++ b/spec/filter_spec.rb
@@ -1,17 +1,17 @@
 require File.expand_path('../spec_helper', __FILE__)
 
 describe IsItWorking::Filter do
-  
+
   it "should have a name" do
     filter = IsItWorking::Filter.new(:test, lambda{})
     filter.name.should == :test
   end
-  
+
   it "should run a check and return a thread" do
     check = lambda do |status|
       status.ok("success")
     end
-    
+
     filter = IsItWorking::Filter.new(:test, check)
     runner = filter.run
     status = runner.filter_status
@@ -20,12 +20,12 @@ describe IsItWorking::Filter do
     status.messages.first.message.should == "success"
     status.time.should_not be_nil
   end
-  
-  it "should run a check and recue an errors" do
+
+  it "should run a check and rescue an error" do
     check = lambda do |status|
       raise "boom!"
     end
-    
+
     filter = IsItWorking::Filter.new(:test, check)
     runner = filter.run
     status = runner.filter_status
@@ -34,7 +34,13 @@ describe IsItWorking::Filter do
     status.messages.first.message.should include("boom")
     status.time.should_not be_nil
   end
-  
+
+  it "should have a warn state when exceeding the warn_threshold" do
+  end
+
+  it "should have a warn state when exceeding the warn_threshold" do
+  end
+
   it "should run multiple filters and return their statuses" do
     filter_1 = IsItWorking::Filter.new(:test, lambda{|status| status.ok("OK")})
     filter_2 = IsItWorking::Filter.new(:test, lambda{|status| status.fail("FAIL")})
@@ -42,5 +48,5 @@ describe IsItWorking::Filter do
     statuses.first.should be_success
     statuses.last.should_not be_success
   end
-  
+
 end

--- a/spec/handler_spec.rb
+++ b/spec/handler_spec.rb
@@ -100,7 +100,7 @@ describe IsItWorking::Handler do
 
   it "should return a warning status if a check exceeds a warning timeout" do
     handler = IsItWorking::Handler.new do |h|
-      h.timer(warn: 1) do
+      h.timer(warn_after: 1) do
         h.check :block do |status|
           sleep 0.02
           status.ok('That took a while! 😅')
@@ -115,13 +115,13 @@ describe IsItWorking::Handler do
 
     it "should return a failure status if a check exceeds a warning timeout and a timeout" do
     handler = IsItWorking::Handler.new do |h|
-      h.timer(9, warn: 5) do
+      h.timer(warn_after: 5, fail_after: 9) do
         h.check :block do |status|
           sleep 0.1
           status.ok('That took a while! 😅')
         end
       end
-      h.timer(warn: 5) do
+      h.timer(warn_after: 5) do
         h.check :warn do |status|
           sleep 0.1
           status.ok('That took a while! 😅')

--- a/spec/handler_spec.rb
+++ b/spec/handler_spec.rb
@@ -100,26 +100,32 @@ describe IsItWorking::Handler do
 
   it "should return a warning status if a check exceeds a warning timeout" do
     handler = IsItWorking::Handler.new do |h|
-      h.check :block, warn_timeout: 900 do |status|
-        sleep 1
-        status.ok('That took a while! 😅')
+      h.timer(warn: 1) do
+        h.check :block do |status|
+          sleep 0.02
+          status.ok('That took a while! 😅')
+        end
       end
     end
     response = handler.call({})
-    response.first.should == 203
+    response.first.should == 302
     response.last.flatten.join.should include("OK: block - That took a while")
     response.last.flatten.join.should include("WARN: block - runtime exceeded warning threshold")
   end
 
     it "should return a failure status if a check exceeds a warning timeout and a timeout" do
     handler = IsItWorking::Handler.new do |h|
-      h.check :block,  warn_timeout: 5, timeout: 9 do |status|
-        sleep 0.1
-        status.ok('That took a while! 😅')
+      h.timer(9, warn: 5) do
+        h.check :block do |status|
+          sleep 0.1
+          status.ok('That took a while! 😅')
+        end
       end
-      h.check :warn, warn_timeout: 5 do |status|
-        sleep 0.1
-        status.ok('That took a while! 😅')
+      h.timer(warn: 5) do
+        h.check :warn do |status|
+          sleep 0.1
+          status.ok('That took a while! 😅')
+        end
       end
     end
     response = handler.call({})

--- a/spec/handler_spec.rb
+++ b/spec/handler_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe IsItWorking::Handler do
-  
+
   it "should lookup filters from the pre-defined checks" do
     handler = IsItWorking::Handler.new do |h|
       h.check :directory, :path => ".", :permissions => :read
@@ -11,7 +11,7 @@ describe IsItWorking::Handler do
     response.last.flatten.join("").should include("OK")
     response.last.flatten.join("").should include("directory")
   end
-  
+
   it "should use blocks as filters" do
     handler = IsItWorking::Handler.new do |h|
       h.check :block do |status|
@@ -23,7 +23,7 @@ describe IsItWorking::Handler do
     response.last.flatten.join("").should include("OK")
     response.last.flatten.join("").should include("block - Okey dokey")
   end
-  
+
   it "should use object as filters" do
     handler = IsItWorking::Handler.new do |h|
       h.check :lambda, lambda{|status| status.ok("A-okay")}
@@ -33,7 +33,7 @@ describe IsItWorking::Handler do
     response.last.flatten.join("").should include("OK")
     response.last.flatten.join("").should include("lambda - A-okay")
   end
-  
+
   it "should create asynchronous filters by default" do
     handler = IsItWorking::Handler.new do |h|
       h.check :block do |status|
@@ -44,7 +44,7 @@ describe IsItWorking::Handler do
     IsItWorking::Filter::AsyncRunner.should_receive(:new).and_return(runner)
     response = handler.call({})
   end
-  
+
   it "should be able to create synchronous filters" do
     handler = IsItWorking::Handler.new do |h|
       h.check :block, :async => false do |status|
@@ -55,7 +55,7 @@ describe IsItWorking::Handler do
     IsItWorking::Filter::SyncRunner.should_receive(:new).and_return(runner)
     response = handler.call({})
   end
-  
+
   it "should work with synchronous checks" do
     handler = IsItWorking::Handler.new do |h|
       h.check :block, :async => false do |status|
@@ -67,7 +67,7 @@ describe IsItWorking::Handler do
     response.last.flatten.join("").should include("OK")
     response.last.flatten.join("").should include("block - Okey dokey")
   end
-  
+
   it "should return a success response if all checks pass" do
     handler = IsItWorking::Handler.new do |h|
       h.check :block do |status|
@@ -82,7 +82,7 @@ describe IsItWorking::Handler do
     response.last.flatten.join("").should include("block - success")
     response.last.flatten.join("").should include("block - worked")
   end
-  
+
   it "should return an error response if any check fails" do
     handler = IsItWorking::Handler.new do |h|
       h.check :block do |status|
@@ -97,7 +97,33 @@ describe IsItWorking::Handler do
     response.last.flatten.join("").should include("block - success")
     response.last.flatten.join("").should include("block - down")
   end
-  
+
+  it "should return a warning status if a check exceeds a warning timeout" do
+    handler = IsItWorking::Handler.new do |h|
+      h.check :block, warn_timeout: 900 do |status|
+        sleep 1
+        status.ok('That took a while! 😅')
+      end
+    end
+    response = handler.call({})
+    response.first.should == 203
+    response.last.flatten.join.should include("OK: block - That took a while")
+    response.last.flatten.join.should include("WARN: block - runtime exceeded warning threshold")
+  end
+
+    it "should return a failure status if a check exceeds a warning timeout and a timeout" do
+    handler = IsItWorking::Handler.new do |h|
+      h.check :block,  warn_timeout: 500, timeout: 900 do |status|
+        sleep 1
+        status.ok('That took a while! 😅')
+      end
+    end
+    response = handler.call({})
+    response.first.should == 500
+    response.last.flatten.join.should include("OK: block - That took a while")
+    response.last.flatten.join.should include("FAIL: block - runtime exceeded critical threshold")
+  end
+
   it "should be able to be used in a middleware stack with the route /is_it_working" do
     app_response = [200, {"Content-Type" => "text/plain"}, ["OK"]]
     app = lambda{|env| app_response}
@@ -105,13 +131,13 @@ describe IsItWorking::Handler do
     stack = IsItWorking::Handler.new(app) do |h|
       h.check(:test){|status| check_called = true; status.ok("Woot!")}
     end
-    
+
     stack.call("PATH_INFO" => "/").should == app_response
     check_called.should == false
     stack.call("PATH_INFO" => "/is_it_working").last.flatten.join("").should include("Woot!")
     check_called.should == true
   end
-  
+
   it "should be able to be used in a middleware stack with a custom route" do
     app_response = [200, {"Content-Type" => "text/plain"}, ["OK"]]
     app = lambda{|env| app_response}
@@ -119,19 +145,19 @@ describe IsItWorking::Handler do
     stack = IsItWorking::Handler.new(app, "/woot") do |h|
       h.check(:test){|status| check_called = true; status.ok("Woot!")}
     end
-    
+
     stack.call("PATH_INFO" => "/is_it_working").should == app_response
     check_called.should == false
     stack.call("PATH_INFO" => "/woot").last.flatten.join("").should include("Woot!")
     check_called.should == true
   end
-  
+
   it "should be able to synchronize access to a block" do
     handler = IsItWorking::Handler.new
     handler.synchronize{1}.should == 1
     handler.synchronize{2}.should == 2
   end
-  
+
   it "should be able to set the host name reported in the output" do
     handler = IsItWorking::Handler.new
     handler.hostname = "woot"

--- a/spec/handler_spec.rb
+++ b/spec/handler_spec.rb
@@ -113,8 +113,12 @@ describe IsItWorking::Handler do
 
     it "should return a failure status if a check exceeds a warning timeout and a timeout" do
     handler = IsItWorking::Handler.new do |h|
-      h.check :block,  warn_timeout: 500, timeout: 900 do |status|
-        sleep 1
+      h.check :block,  warn_timeout: 5, timeout: 9 do |status|
+        sleep 0.1
+        status.ok('That took a while! 😅')
+      end
+      h.check :warn, warn_timeout: 5 do |status|
+        sleep 0.1
         status.ok('That took a while! 😅')
       end
     end

--- a/spec/status_spec.rb
+++ b/spec/status_spec.rb
@@ -34,6 +34,16 @@ describe IsItWorking::Status do
     status.messages.first.message.should == "uh oh"
   end
 
+  it "should have failures" do
+    status.fail("uh oh")
+    status.should be_failures
+    status.messages.size.should == 1
+    status.messages.first.should_not be_ok
+    status.messages.first.should_not be_warn
+    status.messages.first.should be_fail
+    status.messages.first.message.should == "uh oh"
+  end
+
   it "should have both errors and successes" do
     status.fail("boom")
     status.ok("wow")


### PR DESCRIPTION
### Why?
We have had [success benchmarking checks and using the runtime to determine whether to pass or fail](https://github.com/customink/groups/blob/master/config/initializers/is_it_working.rb#L29-L39) in the past, but not every check can support a body to execute in this way. The builtin checks, for example, don't have a block interface to inject code, and we wouldn't be able to achieve something as simple as erroring when dalli pings take more than 100ms. Because such a condition would likely put many of our apps in an unusable state, it's important that we get this kind of visibility into is_it_working. Likewise, it would be nice to not have to repeat the `Benchmark` code and subsequent time comparison logic in every check that needs to be measured.

We can fix this by introducing a timer that can wrap checks and perform additional `warn` or `fail` calls on a status based on timing.

### Changes
- Light refactors around filter execution to expose `status` and `runner` upward
- Addition of a `Timer` class and `Handler#timer` method to create one
  - Note: Timers must yield to a filter on initialization, so `h.check` must be the last thing in an `h.timer` block
- `Handler#call` now iterates timers and compares the reference times to the relevant filter's actual run time, and amends the status with messages as necessary.
- Now returning a `302` status when there are warnings. Nagios will 'warn' when it encounters something in the `3xx` range so this feels right.

### JIRA Ticket
No JIRA, but relevant to action items around recent Imgix postmortems

### Screenshots
![image](https://user-images.githubusercontent.com/72645/67603134-1397d600-f746-11e9-89c9-6ec552233c02.png)


Supersedes #1 