### PR TITLE
Implement Reporters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - 2020-02-04
+
+### Added
+
+- Handler now exposes a `reporter` method to log or track time series statistics of check performance
+
 ## [1.2.1] - 2020-02-01
 
 ### Fixed
 
 - There is no `hostname` on Lambda.
-
 
 ## [1.2.0] - 2019-11-15
 

--- a/lib/is_it_working.rb
+++ b/lib/is_it_working.rb
@@ -5,6 +5,7 @@ module IsItWorking
   autoload :Check, File.expand_path("../is_it_working/check.rb", __FILE__)
   autoload :Filter, File.expand_path("../is_it_working/filter.rb", __FILE__)
   autoload :Handler, File.expand_path("../is_it_working/handler.rb", __FILE__)
+  autoload :Reporter, File.expand_path("../is_it_working/reporter.rb", __FILE__)
   autoload :Status, File.expand_path("../is_it_working/status.rb", __FILE__)
   autoload :Timer, File.expand_path("../is_it_working/timer.rb", __FILE__)
 

--- a/lib/is_it_working/handler.rb
+++ b/lib/is_it_working/handler.rb
@@ -35,6 +35,7 @@ module IsItWorking
       @hostname = `hostname`.to_s.chomp
       @timers = []
       @filters = []
+      @reporters = []
       @mutex = Mutex.new
       yield self if block_given?
     end
@@ -45,6 +46,7 @@ module IsItWorking
         t = Time.now
         statuses = Filter.run_filters(@filters)
         Timer.run_timers(@timers)
+        Reporter.run_reporters(@reporters, @filters)
         render(statuses, Time.now - t)
       else
         @app.call(env)
@@ -113,6 +115,10 @@ module IsItWorking
 
     def timer(*args, **kwargs)
       @timers << Timer.new(*args, **kwargs) { yield }
+    end
+
+    def reporter(filters, &block)
+      @reporters << Reporter.new(filters, block)
     end
 
     protected

--- a/lib/is_it_working/reporter.rb
+++ b/lib/is_it_working/reporter.rb
@@ -1,0 +1,29 @@
+module IsItWorking
+  class Reporter
+    attr_reader :name, :filters, :func
+
+    def initialize(filters, func)
+      @filters = filters
+      @func = func
+    end
+
+    def report_on?(filter)
+      filters.include? filter.name
+    end
+
+    def report(filter)
+      func.call(filter.name, filter.status&.time.to_f)
+    end
+
+    class << self
+      # Run reporters for each named filter in their respective lists
+      def run_reporters(reporters, filters)
+        reporters.each do |reporter|
+          filters.each do |filter|
+            reporter.report(filter) if reporter.report_on? filter
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/is_it_working/version.rb
+++ b/lib/is_it_working/version.rb
@@ -1,3 +1,3 @@
 module IsItWorking
-  VERSION = '1.2.1'.freeze
+  VERSION = '1.3.0'.freeze
 end

--- a/spec/handler_spec.rb
+++ b/spec/handler_spec.rb
@@ -113,7 +113,7 @@ describe IsItWorking::Handler do
     response.last.flatten.join.should include("WARN: block - runtime exceeded warning threshold")
   end
 
-    it "should return a failure status if a check exceeds a warning timeout and a timeout" do
+  it "should return a failure status if a check exceeds a warning timeout and a timeout" do
     handler = IsItWorking::Handler.new do |h|
       h.timer(warn_after: 5, fail_after: 9) do
         h.check :block do |status|
@@ -132,6 +132,23 @@ describe IsItWorking::Handler do
     response.first.should == 500
     response.last.flatten.join.should include("OK: block - That took a while")
     response.last.flatten.join.should include("FAIL: block - runtime exceeded critical threshold")
+  end
+
+  it "should invoke a reporter with the specified filters" do
+    handler = IsItWorking::Handler.new do |h|
+      h.check :block do |status|
+        sleep 0.1
+        status.ok('That took a while! 😅')
+      end
+
+      h.reporter [:block] do |name, time|
+        @name = name
+        @time = time
+      end
+    end
+    handler.call({})
+    @name.should == :block
+    @time.should > 0.1
   end
 
   it "should be able to be used in a middleware stack with the route /is_it_working" do


### PR DESCRIPTION
### Description
This allows us to execute code blocks to be passed timing information for a set of specified filters, opening the door for time-series metrics and logging.

#### Usage
Add a `reporter` block to your handler, passing an array of check names to report on. The block receives the name of the check being reported on, and its run time. From there, you can push to cloudwatch, pipe metrics to newrelic, etc.

From the test suite:
```ruby
handler = IsItWorking::Handler.new do |h|
  h.check :block do |status|
    sleep 0.1
    status.ok('That took a while! 😅')
  end

  h.reporter [:block] do |name, time|
    @name = name
    @time = time
  end
end

> @name
#=> :block
> @time
#=> 0.10001
```

### Changes

- Added `Reporter` class to expose a filter's results to integrators
- Connected reporters to the `Handler` via `Handler#reporter`
