### PR TITLE
Add IsItWorking::Handler::BasicAuth

### DIFF
--- a/lib/is_it_working.rb
+++ b/lib/is_it_working.rb
@@ -2,9 +2,10 @@ require 'time'
 require 'thread'
 
 module IsItWorking
+  HANDLER_PATH = '/is_it_working'
+
   autoload :Check, File.expand_path("../is_it_working/check.rb", __FILE__)
   autoload :Filter, File.expand_path("../is_it_working/filter.rb", __FILE__)
-  autoload :Handler, File.expand_path("../is_it_working/handler.rb", __FILE__)
   autoload :Reporter, File.expand_path("../is_it_working/reporter.rb", __FILE__)
   autoload :Status, File.expand_path("../is_it_working/status.rb", __FILE__)
   autoload :Timer, File.expand_path("../is_it_working/timer.rb", __FILE__)
@@ -16,4 +17,10 @@ module IsItWorking
   autoload :DirectoryCheck, File.expand_path("../is_it_working/checks/directory_check.rb", __FILE__)
   autoload :PingCheck, File.expand_path("../is_it_working/checks/ping_check.rb", __FILE__)
   autoload :UrlCheck, File.expand_path("../is_it_working/checks/url_check.rb", __FILE__)
+
+  require 'is_it_working/handler'
+
+  class Handler
+    autoload :BasicAuth, File.expand_path("../is_it_working/handler/basic_auth.rb", __FILE__)
+  end
 end

--- a/lib/is_it_working/handler.rb
+++ b/lib/is_it_working/handler.rb
@@ -29,7 +29,7 @@ module IsItWorking
     # Rails 3+ routes.rb file. Otherwise, an application stack can be supplied in the first
     # argument and a routing path in the second (defaults to <tt>/is_it_working</tt>) so
     # it can be used with the rackup +use+ method or in Rails.middleware.
-    def initialize(app=nil, route_path="/is_it_working", &block)
+    def initialize(app=nil, route_path=IsItWorking::HANDLER_PATH, &block)
       @app = app
       @route_path = route_path
       @hostname = `hostname`.to_s.chomp

--- a/lib/is_it_working/handler/basic_auth.rb
+++ b/lib/is_it_working/handler/basic_auth.rb
@@ -1,0 +1,39 @@
+begin
+  require 'rack'
+rescue NameError
+  raise NameError, 'IsItWorking::Handler::BasicAuth requires rack, please add it to your Gemfile.'
+end
+
+module IsItWorking
+  class Handler
+    # A middleware to implement a basic authentication flow before providing access to is_it_working endpoints
+    class BasicAuth
+      def initialize(app=nil, route_path=IsItWorking::HANDLER_PATH, &block)
+        @app = app
+        @handler = ::IsItWorking::Handler.new(app, route_path, &block)
+        @route_path = route_path
+      end
+
+      def call(env)
+        if @app.nil? || env['PATH_INFO'] == @route_path
+          auth = Rack::Auth::Basic.new(@handler) do |u, p|
+            u == username && p == password
+          end
+          auth.call(env)
+        else
+          @app.call(env)
+        end
+      end
+
+      private
+
+      def username
+        ENV['IS_IT_WORKING_USERNAME']
+      end
+
+      def password
+        ENV['IS_IT_WORKING_PASSWORD']
+      end
+    end
+  end
+end

--- a/spec/handler/basic_auth_spec.rb
+++ b/spec/handler/basic_auth_spec.rb
@@ -1,0 +1,82 @@
+require 'spec_helper'
+
+describe IsItWorking::Handler::BasicAuth do
+  let(:credential) { 'test' }
+  let(:auth) { 'Basic dGVzdDp0ZXN0' }
+  let(:invalid_auth) { 'Basic abcdefg' }
+  let(:path) { '/is_it_working' }
+  let(:unmatched_path) { '/' }
+  let(:handler) do
+    IsItWorking::Handler::BasicAuth.new do |h|
+      h.check :directory, :path => ".", :permissions => :read
+    end
+  end
+
+  before do
+    ENV['IS_IT_WORKING_USERNAME'] = ENV['IS_IT_WORKING_PASSWORD'] = credential
+  end
+
+  it 'should challenge with a 401 if credentials are not provided' do
+    env = { 'PATH_INFO' => path }
+    response = handler.call(env)
+
+    response.first.should == 401
+    response.last.flatten.join("").should == ""
+    response.second.keys.should include('WWW-Authenticate')
+  end
+
+  it 'should call the handler if correct credentials are provided' do
+    env = { 'PATH_INFO' => path, 'HTTP_AUTHORIZATION' => auth }
+    response = handler.call(env)
+
+    response.first.should == 200
+    response.last.flatten.join("").should include("OK")
+    response.last.flatten.join("").should include("directory")
+  end
+
+  it 'should challenge with a 401 if incorrect credentials are provided' do
+    env = { 'PATH_INFO' => path, 'HTTP_AUTHORIZATION' => invalid_auth }
+    response = handler.call(env)
+
+    response.first.should == 401
+    response.last.flatten.join("").should == ""
+    response.second.keys.should include('WWW-Authenticate')
+  end
+
+  it "should challenge with a 401 if @app is nil and the path does not match" do
+    env = { 'PATH_INFO' => unmatched_path }
+    response = handler.call(env)
+
+    response.first.should == 401
+    response.last.flatten.join("").should == ""
+    response.second.keys.should include('WWW-Authenticate')
+  end
+
+  context "when @app is present" do
+    let(:app) { double('@app') }
+    let(:handler) do
+      IsItWorking::Handler::BasicAuth.new(app) do |h|
+        h.check :directory, :path => ".", :permissions => :read
+      end
+    end
+
+    it "should delegate to @app if the path does not match" do
+      env = { 'PATH_INFO' => unmatched_path }
+      app.should receive(:call).with(env).and_return([200, {}, ['OK']])
+      response = handler.call(env)
+
+      response.first.should == 200
+      response.last.flatten.join("").should include("OK")
+    end
+
+    it "should challenge with a 401 if the path does match" do
+      env = { 'PATH_INFO' => path }
+      app.should_not receive(:call)
+      response = handler.call(env)
+
+      response.first.should == 401
+      response.last.flatten.join("").should == ""
+      response.second.keys.should include('WWW-Authenticate')
+    end
+  end
+end


### PR DESCRIPTION
### Description

Recent reconfigurations of our upstream proxies have exposed many is it working handlers to the public internet. This leaks internal hostnames of underlying hardware, and we should replace the basic auth that used to be present.

Basic auth still allows external pings to access these endpoints and report on them, and is a good intermediate stopgap before getting into some other mechanism than http for observability / running these checks.

To use:
1. Ensure that the environment variables, `IS_IT_WORKING_USERNAME` and `IS_IT_WORKING_PASSWORD` are set
2. Replace `Rails.configuration.middleware.use(IsItWorking::Handler)` with 
 `Rails.configuration.middleware.use(IsItWorking::Handler::BasicAuth)`

### Changes

- Added a `Handler::BasicAuth` class to wrap the is it working handler class with a Rack::Auth::Basic middleware
- Eagerly required the `Handler` class to avoid load issues when defining the autoload for the `BasicAuth` handler

##### Updated Dependencies
 - Rack is required to use the BasicAuth handler, but not the rest of the application. No dependency is added; rather the NameError is rescued and re-raised with a more helpful message.

### Notes

Is there a better way to maintain compatibility with the current `IsItWorking::Handler` syntax without the require gymnastics? I couldn't come up with anything good off the top of my head.

### Optional Tasks

<!--
Common, optional tasks are included here in case you forgot something important.
-->

- [ ] Include 🎩 Instructions
- [ ] Update the readme (README.md)
- [ ] Update the API or architecture docs (e.g. docs/api.md)

##### Library-Specific

- [ ] Increment the changelog (CHANGELOG.md)
- [ ] Increment the version number (lib/version.rb)
- [ ] [Release & Tag][release] the version above in Github

[release]: https://docs.github.com/en/github/administering-a-repository/managing-releases-in-a-repository
