### PR TITLE
[Bugfix] Remedy hostname "No such file" error, enforce string type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [1.3.1] - 2022-02-25
+
+### Fixed
+
+- There is no `hostname` on Lambda. Use return status of `which hostname` before calling `hostname`.
+- Enforce string type on `hostname=` method using `to_s`
+- Change length-check on `@hostname` to use Ruby `empty?` predicate method
+
 ## [1.3.0] - 2020-02-04
 
 ### Added

--- a/lib/is_it_working/handler.rb
+++ b/lib/is_it_working/handler.rb
@@ -32,7 +32,7 @@ module IsItWorking
     def initialize(app=nil, route_path="/is_it_working", &block)
       @app = app
       @route_path = route_path
-      @hostname = `hostname`.to_s.chomp
+      @hostname = %x(which hostname >/dev/null && hostname).chomp
       @timers = []
       @filters = []
       @reporters = []
@@ -57,7 +57,7 @@ module IsItWorking
     # the system hostname. You should override it if the value reported as the hostname by
     # the system is not useful or if exposing it publicly would create a security risk.
     def hostname=(val)
-      @hostname = val
+      @hostname = val.to_s
     end
 
     # Add a status check to the handler.
@@ -159,7 +159,7 @@ module IsItWorking
       end
 
       info = []
-      info << "Host: #{@hostname}" unless @hostname.size == 0
+      info << "Host: #{@hostname}" unless @hostname.empty?
       info << "PID:  #{$$}"
       info << "Timestamp: #{Time.now.iso8601}"
       info << "Elapsed Time: #{(elapsed_time * 1000).round}ms"

--- a/lib/is_it_working/version.rb
+++ b/lib/is_it_working/version.rb
@@ -1,3 +1,3 @@
 module IsItWorking
-  VERSION = '1.3.0'.freeze
+  VERSION = '1.3.1'.freeze
 end


### PR DESCRIPTION
### Description

The change in version `1.2.1` was insufficient to prevent the system-level `No such file or directory` error from occurring when there is no `hostname` executable or alias on the underlying platform. This fix uses `&&` to check the return status of `which hostname` before attempting to execute it, which avoids that error in most circumstances (unless `which` itself doesn't resolve, which is an even more extreme linux configuration).

In addition, we can enforce the string type in the `hostname=` setter method, taking for granted that the return of `%x()` will be a string as well, and we can use the `empty?` predicate method to check its presence rather than the `size` or `length` methods.

### What GIF Best Describes This Pull Request?

![](https://media.giphy.com/media/TdEGyGzisGyfDVPIHB/giphy-downsized.gif)