### PR TITLE
Explicit error handling for timer failure

### DIFF
--- a/lib/is_it_working/timer.rb
+++ b/lib/is_it_working/timer.rb
@@ -1,5 +1,7 @@
 module IsItWorking
   class Timer
+    class TimerFailedError < StandardError; end;
+    
     attr_reader :failure_threshold, :filter, :warning_threshold
 
     def initialize(warn_after: Float::INFINITY, fail_after: Float::INFINITY)
@@ -15,6 +17,8 @@ module IsItWorking
       elsif warn_timeout_exceeded?(status.time)
         status.warn("runtime exceeded warning threshold: #{warning_threshold}ms")
       end
+    rescue Exception => e
+      raise TimerFailedError.new("Failed to run timer for status check #{status.name}: #{e.message}")
     end
 
     class << self


### PR DESCRIPTION
### Stakeholder Overview _[(learn more)](https://app.getguru.com/card/TGyLkrnc/Pull-Review-Stakeholder-Overview)_
We have [a mysterious failure](https://app.rollbar.com/a/customink/fix/item/checkout/1113) from `is_it_working` which lacks context about which check it is coming from. This has the gem "blow up" in the same way as it currently does, but adds some context about what is causing it to blow up - namely, the name of the status check being run.

### Risk Estimate _[(learn more)](https://app.getguru.com/card/iMnRRRjT/Pull-Request-Risk-Estimate)_
This is a minor update to the behavior of a specific exception in the gem that is already resulting in a raise. Very low risk.

- [ ] Big/complex change?
- [ ] Big splash zone?
- [ ] High stakes if errors occur?
- [ ] Low confidence?
- [x] Not hidden by feature flag?
- [ ] Negligible risk!

### Changes
- Explicitly handle errors in `Timer#call` using a custom error class and message.